### PR TITLE
fix: Added MR_ prefix to list_empty+tail

### DIFF
--- a/extras/graphics/mercury_tcltk/mtcltk.m
+++ b/extras/graphics/mercury_tcltk/mtcltk.m
@@ -154,7 +154,7 @@
     MR_incr_hp(argv_word, argc + 1);
     argv = (char **) argv_word;
 
-    for (i = 0, l = Args; l != list_empty(); l = list_tail(l), i++) {
+    for (i = 0, l = Args; l != MR_list_empty(); l = MR_list_tail(l), i++) {
         argv[i] = (char *) MR_list_head(l);
     }
     


### PR DESCRIPTION
In line 157, the MR_ prefix was missing from the list_empty and list_tail calls, now the library is compiling properly from the master branch
