### PR TITLE
fix C macro name in C++ FFI example

### DIFF
--- a/samples/c_interface/simpler_cplusplus_calls_mercury/main.cc
+++ b/samples/c_interface/simpler_cplusplus_calls_mercury/main.cc
@@ -100,7 +100,7 @@ static void print_list(MercuryList list) {
 		printf("[");
 		printf("%ld", (long) MR_list_head(list));
 		list = MR_list_tail(list);
-		while (!list_is_empty(list)) {
+		while (!MR_list_is_empty(list)) {
 			printf(", %ld", (long) MR_list_head(list));
 			list = MR_list_tail(list);
 		}


### PR DESCRIPTION
This fixes the macro usage for `MR_list_is_empty(list)' in file
`samples/c_interface/simpler_cplusplus_calls_mercury/main.cc`.