### PR TITLE
Add --output-csharp-compiler option

### DIFF
--- a/compiler/mercury_compile.m
+++ b/compiler/mercury_compile.m
@@ -372,6 +372,7 @@ main_after_setup(DetectedGradeFlags, OptionVariables, OptionArgs, Args,
     globals.lookup_bool_option(Globals, output_cc, OutputCC),
     globals.lookup_bool_option(Globals, output_c_compiler_type, OutputCCType),
     globals.lookup_bool_option(Globals, output_cflags, OutputCFlags),
+    globals.lookup_bool_option(Globals, output_csharp_compiler, OutputCSC),
     globals.lookup_bool_option(Globals, output_csharp_compiler_type,
         OutputCSCType),
     globals.lookup_bool_option(Globals, output_library_link_flags,
@@ -442,6 +443,10 @@ main_after_setup(DetectedGradeFlags, OptionVariables, OptionArgs, Args,
         io.stdout_stream(StdOut, !IO),
         output_c_compiler_flags(Globals, StdOut, !IO),
         io.nl(StdOut, !IO)
+    ; OutputCSC = yes ->
+        globals.lookup_string_option(Globals, csharp_compiler, CSC),
+        io.stdout_stream(StdOut, !IO),
+        io.write_string(StdOut, CSC ++ "\n", !IO)
     ; OutputCSCType = yes ->
         globals.lookup_string_option(Globals, csharp_compiler_type, CSC_Type),
         io.stdout_stream(StdOut, !IO),

--- a/compiler/options.m
+++ b/compiler/options.m
@@ -209,6 +209,7 @@
     ;       output_libgrades
     ;       output_cc
     ;       output_c_compiler_type
+    ;       output_csharp_compiler
     ;       output_csharp_compiler_type
     ;       output_cflags
     ;       output_library_link_flags
@@ -1216,6 +1217,7 @@ option_defaults_2(output_option, [
     output_libgrades                    -   bool(no),
     output_cc                           -   bool(no),
     output_c_compiler_type              -   bool(no),
+    output_csharp_compiler              -   bool(no),
     output_csharp_compiler_type         -   bool(no),
     output_cflags                       -   bool(no),
     output_library_link_flags           -   bool(no),
@@ -2127,6 +2129,7 @@ long_option("output-libgrades",         output_libgrades).
 long_option("output-cc",                output_cc).
 long_option("output-cc-type",           output_c_compiler_type).
 long_option("output-c-compiler-type",   output_c_compiler_type).
+long_option("output-csharp-compiler",   output_csharp_compiler).
 long_option("output-csharp-compiler-type", output_csharp_compiler_type).
 long_option("output-cflags",            output_cflags).
 long_option("output-library-link-flags",    output_library_link_flags).
@@ -3887,6 +3890,9 @@ options_help_output -->
         "--output-cflags",
         "\tPrint the flags with which the C compiler will be invoked",
         "\tto the standard output.",
+        "--output-csharp-compiler",
+        "\tPrint the command used to invoke the C# compiler to the",
+        "\tstandard output.",
         "--output-csharp-compiler-type",
         "\tPrint the C# compiler type to the standard output.",
         "--output-library-link-flags",

--- a/doc/user_guide.texi
+++ b/doc/user_guide.texi
@@ -7061,7 +7061,7 @@ be installed should be built to the standard output.
 @sp 1
 @item --output-cc
 @findex --output-cc
-Print the command used to invoke C compiler to the standard output.
+Print the command used to invoke the C compiler to the standard output.
 
 @sp 1
 @item --output-cc-type
@@ -7075,6 +7075,11 @@ Print the C compiler type to the standard output.
 @findex --output-cflags
 Print the flags with which the C compiler will be invoked
 to the standard output.
+
+@sp 1
+@item --output-csharp-compiler
+@findex --output-csharp-compiler
+Print the command used to invoke the C# compiler to the standard output.
 
 @sp 1
 @item --output-csharp-compiler-type


### PR DESCRIPTION
In order to support more complicated linking scenarios linking .NET code
with Mercury in the C# grade, add the --output-csharp-compiler option
in the same way --output-c-compiler-type and --output-cc work.
This way makefiles can use something like:
CS_COMPILER := $(shell $(MMC) --output-csharp-compiler)

compiler/mercury_compile.m:
    Output the global csharp_compiler if the boolean option
    output_csharp_compiler is set.

compiler/options.m:
    Define the output_csharp_compiler option and provide the help text.

doc/user_guide.texi:
    Document the output option and fix a spelling mistake.