### PR TITLE
[vim] changes requested by Peter

### DIFF
--- a/vim/doc/mercury.txt
+++ b/vim/doc/mercury.txt
@@ -22,25 +22,28 @@ enabled.
 
     $ mkdir ~/.vim
 <
-2.2. There are two ways to install the support files:
+2.2. For installing the Mercury language support, please change into the `vim'
+directory of your Mercury source distribution (or git clone).
 
-2.2.1 Manual: Copy everything recursively from this directory into `~/.vim' >
+There are two ways to install the support files:
+
+2.2.1 Manual: Copy everything recursively from that directory into `~/.vim' >
 
     $ cp -r . ~/.vim
 <
-2.2.2 Using a Vimball: In this directory, invoke: >
+2.2.2 Using a Vimball: In the aforementioned directory, invoke: >
 
     $ make
     $ make install
 
-3. Ensure you have the following lines in your `~/.vimrc' file: >
+2.3. Ensure you have the following lines in your `~/.vimrc' file: >
 
     filetype on
     filetype plugin on
     syntax enable
 <
-4. It is advisable to have the following file encoding detection lines
-in your ~/.vimrc: >
+2.4. It is advisable to have the following file encoding detection lines
+in your `~/.vimrc': >
 
     if has("multi_byte")
       set encoding=utf-8
@@ -50,29 +53,43 @@ in your ~/.vimrc: >
       endif
     endif
 <
-5. Optionally enable |modeline| detection.  This configures vim to use the
+2.5. Optionally enable |modeline| detection.  This configures Vim to use the
 % vim: lines at the beginning of some source files to configure settings
 local to that file. >
 
     set modeline
 <
-6. If you wish to change the colour scheme used by Vim's |syntax-highlighting|,
+The following |modeline| is recommended:>
+
+    % vim: ft=mercury ff=unix ts=4 sw=4 et
+<
+
+2.6. If you wish to change the colour scheme used by Vim's |syntax-highlighting|,
 we suggest you put the necessary commands in `~/.vim/colors/mycolours.vim'
 and append the following to the above list of commands in your `~/.vimrc': >
 
     colors mycolours
 <
-7. If you want to use Vim's |spell-checking| feature, please insert the
-following directive after the |encoding| setting from 4. >
+2.7. If you want to use Vim's |spell-checking| feature, please insert the
+following directive after the |encoding| setting from 2.4. >
 
     " Spelling (comes after encoding, to reduce load time, see :help spell)
     :setlocal spell spelllang=en_gb
->
+<
 =============================================================================
 3. Filetype plugin                                      *mercury-ftplugin*
 
+If the mercury_highlight_extra option from |mercury-syntax| is enabled,
+following keybindings are active: >
+
+    <C-K>r  for renaming variables, starting with the current name
+    <C-K>R  for renaming variables, starting with an empty name
+    <C-K>m  visually marks the current predicate (for copy & pasting)
+<
 =============================================================================
 4. Mercury commands plugin                              *mercury-commands*
+
+TODO: This is work in progess.
 
 mercury_commands |plugin| provides additional functionality via Vim commands:
                                                                     *:Mmc*
@@ -85,7 +102,7 @@ mercury_commands |plugin| provides additional functionality via Vim commands:
 5. Syntax highlighting                                      *mercury-syntax*
 
 The |syntax-highlighting| for mercury can be customised in several ways,
-in your ~/.vimrc file, you can specify following options:
+in your `~/.vimrc' file, you can specify following options:
 
 The default highlighting for  Mercury comments is to only highlight the
 initial `%' and subsequent `line' punctuation characters, likewise
@@ -99,14 +116,13 @@ highlighted.  To avoid this behaviour, add: >
 
     let mercury_no_highlight_overlong = 1
 <
-If folding is supported by the running Vim version, the setting of the
-preferred folding mode for Mercury (currently indent, as it is the fastest)
-can be disabled by >
+If folding is supported by the running Vim version and you want to
+enable folding for Mercury, you can enable folding by: >
 
-    let mercury_no_folding = 1
+    let mercury_folding = 1
 <
 If you want to force the folding setting to indent (despite a different
-setting in the vimrc file), you can enforce it: >
+setting in the `~/.vimrc' file), you can enforce it: >
 
     let mercury_folding_force = 1
 <
@@ -130,10 +146,10 @@ such as `' or ``'': >
 
     let mercury_highlight_comment_special = 1
 <
-If you use Vim 7.3+ with conceal enabled but do not want any concealing
-of operators, use: >
+If you use Vim 7.3+ with conceal enabled and you want to make use
+of that, declare: >
 
-    let mercury_no_conceal = 1
+    let mercury_conceal = 1
 <
 To enable concealing for characters which require a good Unicode font
 and might be "too much" for some users, define: >
@@ -145,5 +161,15 @@ enable concealing for logical operators, such as <=> => <= some all
 by setting: >
 
     let mercury_conceal_logical = 1
+<
+If you want to enforce 78 wide columns with automatic wrapping in
+comments, you can define: >
+
+    let mercury_coding_standard = 1
+<
+If you prefer highlighting of operators, variables and standard foreign types,
+you can enable this with: >
+
+    let mercury_highlight_extra = 1
 <
 vim:tw=78:ts=4:ft=help:norl:et:

--- a/vim/syntax/mercury.vim
+++ b/vim/syntax/mercury.vim
@@ -2,7 +2,9 @@
 " Language:     Mercury
 " Maintainer:   Sebastian Godelet <sebastian.godelet@outlook.com>
 " Extensions:   *.m *.moo
-" Last Change:  2015-04-07
+" Last Change:  2015-04-16
+
+" for documentation, please use :help mercury-syntax
 
 if exists("b:current_syntax")
   finish
@@ -11,9 +13,10 @@ let b:current_syntax = "mercury"
 
   " Mercury is case sensitive.
 syn case match
-set synmaxcol=100
 
-if has("folding") && (!exists("mercury_no_folding") || !mercury_no_folding)
+set synmaxcol=250
+
+if has("folding") && exists("mercury_folding") && mercury_folding
     " folding is only changed (if not forced) if the Vim default (manual) is active,
     " this avoids conflicts with existing user settings
   if (&fdm == "manual") || (exists("mercury_folding_force") && mercury_folding_force)
@@ -29,7 +32,7 @@ endif
 syn match mercurySingleton      "\v<_([A-Z][a-z_A-Z0-9]*)?>"
 syn keyword mercuryKeyword      any_func
 syn keyword mercuryKeyword      any_pred
-syn keyword mercuryKeyword      atomic
+syn keyword mercuryLogical      atomic
 syn keyword mercuryKeyword      cc_multi
 syn keyword mercuryKeyword      cc_nondet
 syn keyword mercuryKeyword      det
@@ -52,30 +55,30 @@ syn keyword mercuryKeyword      module
 syn keyword mercuryKeyword      multi
 syn keyword mercuryKeyword      mutable
 syn keyword mercuryKeyword      nondet
-syn keyword mercuryKeyword      or_else
+syn keyword mercuryLogical      or_else
 syn keyword mercuryKeyword      pragma
 syn keyword mercuryKeyword      pred
 syn keyword mercuryKeyword      promise
-syn keyword mercuryKeyword      require_cc_multi
-syn keyword mercuryKeyword      require_cc_nondet
-syn keyword mercuryKeyword      require_complete_switch
-syn keyword mercuryKeyword      require_det
-syn keyword mercuryKeyword      require_erroneous
-syn keyword mercuryKeyword      require_failure
-syn keyword mercuryKeyword      require_multi
-syn keyword mercuryKeyword      require_nondet
-syn keyword mercuryKeyword      require_semidet
-syn keyword mercuryKeyword      require_switch_arms_cc_multi
-syn keyword mercuryKeyword      require_switch_arms_cc_nondet
-syn keyword mercuryKeyword      require_switch_arms_det
-syn keyword mercuryKeyword      require_switch_arms_erroneous
-syn keyword mercuryKeyword      require_switch_arms_failure
-syn keyword mercuryKeyword      require_switch_arms_multi
-syn keyword mercuryKeyword      require_switch_arms_nondet
-syn keyword mercuryKeyword      require_switch_arms_semidet
+syn keyword mercuryPragma       require_cc_multi
+syn keyword mercuryPragma       require_cc_nondet
+syn keyword mercuryPragma       require_complete_switch
+syn keyword mercuryPragma       require_det
+syn keyword mercuryPragma       require_erroneous
+syn keyword mercuryPragma       require_failure
+syn keyword mercuryPragma       require_multi
+syn keyword mercuryPragma       require_nondet
+syn keyword mercuryPragma       require_semidet
+syn keyword mercuryPragma       require_switch_arms_cc_multi
+syn keyword mercuryPragma       require_switch_arms_cc_nondet
+syn keyword mercuryPragma       require_switch_arms_det
+syn keyword mercuryPragma       require_switch_arms_erroneous
+syn keyword mercuryPragma       require_switch_arms_failure
+syn keyword mercuryPragma       require_switch_arms_multi
+syn keyword mercuryPragma       require_switch_arms_nondet
+syn keyword mercuryPragma       require_switch_arms_semidet
 syn keyword mercuryKeyword      semidet
 syn keyword mercuryKeyword      solver
-syn keyword mercuryKeyword      trace
+syn keyword mercuryPurity       trace
 syn keyword mercuryKeyword      type
 syn keyword mercuryKeyword      typeclass
 syn keyword mercuryKeyword      use_module
@@ -141,7 +144,7 @@ syn match   mercuryOperator     "//"          " (integer) divide
 syn match   mercuryDelimiter    ","           " list seperator or conjunction
 syn match   mercuryOperator     "-"           " substraction operator or unary minus
 syn match   mercuryOperator     "="           " unification
-syn match   mercuryOperator     "|"           " cons
+syn match   mercuryDelimiter    "|"           " cons
 syn match   mercuryImplication  "->"          " 'then' arrow
 syn match   mercuryOperator     "-->"         " DCG clause
 syn match   mercuryOperator     "--->"        " 'typedef'
@@ -169,16 +172,16 @@ syn match   mercuryOperator     "\~="
 syn match   mercuryOperator     ":="         " field update
 syn match   mercuryOperator     ":-"         " reverse implication
 syn match   mercuryOperator     "=:="        " Structural equality (for Prolog)
-syn match   mercuryOperator     "![:.]\?"    " State variable accessors
+syn match   mercuryPurity       "![:.]\?"    " State variable accessors
 syn match   mercuryImplication  ";"          " Disjunction
 syn match   mercuryOperator     "+"          " addition operator or unary plus
 syn match   mercuryOperator     "++"         " concatenation
 syn match   mercuryOperator     ":"
-syn match   mercuryOperator     "::"         " Type/Mode specifier
+syn match   mercuryDelimiter    "::"         " Type/Mode specifier
 syn match   mercuryOperator     "&"          " Parallel conjuction
 syn match   mercuryOperator     "?-"         " Prolog compatability
 syn match   mercuryOperator     "*"          " multiply
-syn match   mercuryOperator     "\^"         " field access
+syn match   mercuryDelimiter    "\^"         " field access
 syn match   mercuryOperator     /\v`[^`']+`/ " inlined operator
 syn match   mercuryImplication  "<=>\|<=\|=>"
 syn match   mercuryNumCode /\v<(0'.|0b[01]+|0o[0-7]+|0x\x+|[0-9]+)/
@@ -202,14 +205,13 @@ syn match   mercuryStringEsc    /\v\\x\x+\\/           contained
 syn match   mercuryStringEsc    /\v\\[0-7][0-7]+\\/    contained
 syn match   mercuryStringEsc    /\v""/ contained
   " matching unbalanced brackets (before "mercuryTerm", "mercuryBlock", ...)
-  " TODO: Verify if contained is required
-syn match mercuryErrInAny       "(\|\[{\|}\|\]\|)"  " contained
+syn match mercuryErrInAny       "(\|\[{\|}\|\]\|)"
 syn match mercuryTerminator     "\v\.(\s+|$)@=" " after mercuryErrInAny
 syn match mercuryOperator       "\.\."          " after mercuryTerminator
 
   " see "https://github.com/Twinside/vim-haskellConceal"
   " see "http://rapidtables.com/math/symbols/Basic_Math_Symbols.htm"
-if has("conceal") && (!exists("mercury_no_conceal") || !mercury_no_conceal)
+if has("conceal") && exists("mercury_conceal") && mercury_conceal
   hi clear Conceal
   hi def link Conceal mercuryOperator
   setlocal conceallevel=2
@@ -279,7 +281,7 @@ syn region  mercuryForeignModList matchgroup=mercuryBracket start='\[' end=']'
       \ mercuryDelimiter,@mercuryComments,@mercuryFormatting,
       \ mercuryString,mercuryOperator,mercuryBlock
 
-syn match mercuryClauseHead /\v^[a-z][a-zA-Z0-9_]*[(]@=/
+syn match mercuryClauseHead /\v^[a-zA-Z][a-zA-Z0-9_.]*[( =]@=/
 
 if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
     " Basic syntax highlighting for foreign code
@@ -311,8 +313,9 @@ if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
 
     " C-Style syntax as a basis for C, C# and Java
   syn keyword mercuryCLikeKeyword contained if else goto switch case for while
-  syn keyword mercuryCLikeKeyword contained do break continue return volatile
-  syn keyword mercuryCLikeKeyword contained extern typedef static default
+  syn keyword mercuryCLikeKeyword contained do break continue return
+  syn keyword mercuryCLikeType contained const static volatile extern typedef
+  syn keyword mercuryCLikeKeyword contained default
   syn keyword mercuryCLikeType contained void int char long byte unsigned signed
   syn keyword mercuryCLikeType contained struct float double enum
   syn match mercuryCLikeDelimiter ";\|," contained
@@ -332,7 +335,7 @@ if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
   syn cluster mercuryCLike add=@mercuryFormatting
 
     " C-Language formatting with Mercury types MR_*
-  syn keyword mercuryCType contained const size_t pid_t offset_t union
+  syn keyword mercuryCType contained size_t pid_t offset_t union
   syn keyword mercuryCType contained MR_bool MR_Bool
   syn keyword mercuryCType contained MR_Word MR_Integer MR_Unsigned
   syn keyword mercuryCType contained MR_ArrayPtr MR_Float MR_file MercuryFile[Ptr]
@@ -340,7 +343,7 @@ if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
   syn match mercuryCType "\v<MR_((Pseudo)?TypeInfo|Construct_Info|TypeCtor(Desc|Info)|AllocSiteInfoPtr)|MercuryLock>" contained
   syn match mercuryCType "\v<(MR_)?[u]?int(_least|_fast)?(8|16|32|64)_t>" contained
   syn match mercuryForeignIface "\v<(MR_)?[U]?INT(_LEAST|_FAST)?(8|16|32|64)_(TYPE|LENGTH_MODIFIER)>" contained
-  syn keyword mercuryCKeyword contained typedef sizeof typeof offsetof
+  syn keyword mercuryCKeyword contained sizeof typeof offsetof
   syn keyword mercuryCConst contained NULL EOF
   syn keyword mercuryCConst contained CHAR_BIT CHAR_MAX CHAR_MIN
   syn keyword mercuryCConst contained SCHAR_BIT SCHAR_MAX SCHAR_MIN
@@ -365,6 +368,7 @@ if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
   syn keyword mercuryCppLikeKeyword contained class new delete try catch finally
         \ instanceof abstract throw[s] extends this super base synchronize[d]
         \ override foreach in using import ref implements
+    " sg - match true and false in foreign (Java/C#) code as boolean types
   syn keyword mercuryCppLikeBool contained true false
   syn keyword mercuryCppLikeConst contained null[ptr]
   syn match mercuryCppLikeOperator "@" contained
@@ -410,7 +414,7 @@ if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
     " Declaration for Erlang
   syn keyword mercuryErlangKeyword contained after and andalso band begin bnot bor bsl bsr bxor case
         \ catch cond end fun if let not of orelse query receive throw try when xor
-  syn keyword mercuryErlangBool true false
+  " syn keyword mercuryErlangBool true false
   syn match mercuryErlangExtNumLiteral "\v([2-9]|[12][0-9]|3[0-6])#[A-Za-z0-9]+" contained
   syn match mercuryErlangOperator "\v[?]" contained
   syn match mercuryErlangLogical "\v[,;.]" contained
@@ -457,59 +461,25 @@ if !exists("mercury_no_highlight_tabs") || !mercury_no_highlight_tabs
   syn cluster mercuryFormatting add=mercuryWhitespace
 endif
 
-  " Comment handling
-syn match mercuryCommentFirstSpace contained "\v[%*]@<=[ ]{1}([\t ]*[\n])@!"
-      \ nextgroup=@mercuryCommentSpecialLines
-syn match mercuryCommentInfo contained "\v(Main |Original )?[Aa]uthor[s]?[^\n:]*[:]@="
-      \ nextgroup=mercuryCommentOp
-syn match mercuryCommentInfo contained "\v(File|Created on|Date|Source|Stability)[:]@="
-      \ nextgroup=mercuryCommentOp
-
-syn keyword mercuryToDo contained XXX TODO NOTE[_TO_IMPLEMENTORS] MISSING HACK
-      \ nextgroup=mercuryCommentOp
-syn keyword mercuryToDo contained HINT WARNING IMPORTANT
-      \ nextgroup=mercuryCommentOp
-
-  " End of special file markers
-syn match mercuryCommentOp contained ": " nextgroup=@mercuryStability
-
-syn match mercuryCopyrightYear "\v (19|20)[0-9][0-9]([, -]+(19|20)[0-9][0-9])*" contained
-if has("conceal") && (!exists("mercury_no_conceal") || !mercury_no_conceal)
-  syn match mercuryCopyrightSymbol "\v\([cC]\)|©" conceal cchar=© contained nextgroup=mercuryCopyrightYear
-else
-  syn match mercuryCopyrightSymbol "\v\([cC]\)|©" contained nextgroup=mercuryCopyrightYear
-endif
-syn match mercuryCommentInfo "\vCopyright " contained nextgroup=mercuryCopyrightSymbol
-
-  " Matching Vim modeline
-syn match mercuryModelineParam contained "\v<(sw|ts|tw|wm|ff|ft|et|expandtab)>"
-syn match mercuryModelineValue contained "\v<(mercury|unix)>"
-syn region mercuryModeline contained matchgroup=mercuryCommentToken start="vim:" end="\v[\n]@="
-      \ oneline contains=mercuryModelineParam,mercuryModelineValue,mercuryNumCode,
-      \ mercuryOperator
-
-  " Highlights the output of the Mercury error command (in extras)
-syn match mercuryCommentErr "\v(\* )@<=###[ ]@=" contained
-
-  " Indicates stability of the module with colours (red, yellow, green)
-syn keyword mercuryStabilityLow    contained low    nextgroup=mercuryStabilityTo
-syn keyword mercuryStabilityMedium contained medium nextgroup=mercuryStabilityTo
-syn keyword mercuryStabilityHigh   contained high
-syn match mercuryStabilityTo "\v-| to " contained nextgroup=@mercuryStability
-
-  " Matches file names, email, file and http addresses (on a best effort basis).
-  " This avoids spell checking on those,
-  " and could also be used for plug-in development to open a browser, etc.
-syn match mercuryCommentUri contained "\v<[-0-9a-zA-Z.+_]+[@][-0-9a-zA-Z.+_]+\.[a-zA-Z]{2,10}>"
-syn match mercuryCommentUri contained "\v<(http[s]?|file)://[^ ><]+>"
-syn match mercuryCommentUri contained "\v<([a-z][a-z0-9._]+[/])*[a-z][a-z0-9._]+[.]m>"
-
-syn cluster mercuryStability contains=mercuryStabilityLow,mercuryStabilityMedium,mercuryStabilityHigh
-syn cluster mercuryCommentSpecialLines contains=mercuryCommentInfo,mercuryModeLine
-syn cluster mercuryCommentDirectives contains=@Spell,mercuryToDo,mercuryCommentFirstSpace
-syn cluster mercuryCommentDirectives add=mercuryCommentUri
-
 if exists("mercury_highlight_comment_special") && mercury_highlight_comment_special
+  syn keyword mercuryToDo contained XXX TODO NOTE[_TO_IMPLEMENTORS] MISSING HACK
+        \ nextgroup=mercuryCommentOp
+  syn keyword mercuryToDo contained HINT WARNING IMPORTANT
+        \ nextgroup=mercuryCommentOp
+  syn match mercuryCommentOp contained ": "
+
+  syn cluster mercuryCommentDirectives contains=@Spell,mercuryToDo,mercuryCommentUri
+
+    " Highlights the output of the Mercury error command (in extras)
+  syn match mercuryCommentErr "\v(\* )@<=###[ ]@=" contained
+
+    " Matches file names, email, file and http addresses (on a best effort basis).
+    " This avoids spell checking on those,
+    " and could also be used for plug-in development to open a browser, etc.
+  syn match mercuryCommentUri contained "\v<[-0-9a-zA-Z.+_]+[@][-0-9a-zA-Z.+_]+\.[a-zA-Z]{2,10}>"
+  syn match mercuryCommentUri contained "\v<(http[s]?|file)://[^ ><]+>"
+  syn match mercuryCommentUri contained "\v<([a-z][a-z0-9._]+[/])*[a-z][a-z0-9._]+[.]m>"
+
   syn match mercuryCommentSlash "/" contained nextgroup=mercuryCommentArity
   syn match mercuryCommentArity "\v\d+" contained
   syn match mercuryCommentSingleQuote /\v'[A-Za-z._0-9()]+'/ contained nextgroup=mercuryCommentSlash
@@ -538,10 +508,12 @@ if exists("mercury_highlight_comment_special") && mercury_highlight_comment_spec
         \ start="\v`[^`]@=" end="\v'" nextgroup=mercuryCommentSlash
   syn region mercuryCommentTexDblQuote start="``" end="''" oneline contained
         \ contains=@Spell
+  syn region mercuryCommentVimLine contained start="\vvim[:]" end="\v[\n]@="
 
-  syn cluster mercuryCommentSpecialLines add=mercuryCommentHeader
+  syn cluster mercuryCommentDirectives add=mercuryCommentHeader
   syn cluster mercuryCommentDirectives add=mercuryCommentSingleQuote
   syn cluster mercuryCommentDirectives add=@mercuryCommentTex
+  syn cluster mercuryCommentDirectives add=mercuryCommentVimLine
   syn cluster mercuryCommentTex contains=mercuryCommentTexDblQuote
   syn cluster mercuryCommentTex contains=mercuryCommentTexSingleQuote
 endif
@@ -568,7 +540,7 @@ else
   hi def link mercuryCppLikeComment Normal
   hi def link mercuryLeadTrailStar  Comment
 
-  syn match mercuryLeadTrailStar contained "^\v[ \t]*[*]+|[*]+$" nextgroup=mercuryCommentFirstSpace
+  syn match mercuryLeadTrailStar contained "^\v[ \t]*[*]+|[*]+$"
   syn region mercuryComment matchgroup=mercuryCommentToken start=/%[-=%*_]*/ end=/\v[\n]@=/ oneline
         \ contains=@mercuryCommentDirectives,@mercuryFormatting
   syn region mercuryCComment matchgroup=mercuryCommentToken start="\v/\*" end="\v[*]+/" keepend fold
@@ -595,10 +567,8 @@ syn sync clear
 syn sync match mercurySync grouphere NONE "\v^[%]------"
 
 hi def link mercuryAccess           Identifier
-hi def link mercurySingleton        Identifier
 hi def link mercuryAtom             Constant
 hi def link mercuryBracket          Delimiter
-hi def link mercuryBool             Special
 hi def link mercuryClauseHead       Statement
 hi def link mercuryCommentErr       ErrorMsg
 hi def link mercuryCommentToken     Comment
@@ -610,10 +580,9 @@ if exists("mercury_highlight_comment_special") && mercury_highlight_comment_spec
   hi def link mercuryCommentSingleQuote  String
   hi def link mercuryCommentTexDblQuote  String
   hi def link mercuryCommentTexSingleQuote  String
+  hi def link mercuryCommentVimLine mercuryComment
 endif
 hi def link mercuryCommentOp        Operator
-hi def link mercuryCopyrightSymbol  Operator
-hi def link mercuryCopyrightYear    Constant
 hi def link mercuryCInterface       mercuryPragma
 if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
   hi def link mercuryForeignId        Identifier
@@ -631,7 +600,7 @@ if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
   hi def link mercuryCFunc            Identifier
   hi def link mercuryCKeyword         Keyword
   hi def link mercuryCStringFmt       mercuryStringFmt
-  hi def link mercuryCType            Type
+  hi def link mercuryCType            mercuryForeignType
   hi def link mercuryCPreProc         mercuryPragma
   hi def link mercuryCppLikeBool      mercuryBool
   hi def link mercuryCppLikeConst     Constant
@@ -643,42 +612,37 @@ if !exists("mercury_no_highlight_foreign") || !mercury_no_highlight_foreign
   hi def link mercuryCSharpString     String
   hi def link mercuryCSharpStringFmt  mercuryStringFmt
   hi def link mercuryCSharpStringFmtEsc mercuryStringEsc
-  hi def link mercuryCSharpType       Type
+  hi def link mercuryCSharpType       mercuryForeignType
   hi def link mercuryJavaBool         mercuryBool
-  hi def link mercuryJavaType         Type
-  hi def link mercuryILType           Type
+  hi def link mercuryJavaType         mercuryForeignType
+  hi def link mercuryILType           mercuryForeignType
   hi def link mercuryErlangKeyword    Keyword
   hi def link mercuryErlangOperator   Operator
   hi def link mercuryErlangBool       mercuryBool
   hi def link mercuryErlangExtNumLiteral Number
   hi def link mercuryErlangString     String
   hi def link mercuryErlangLogical    mercuryLogical
+  if exists("mercury_highlight_extra") && mercury_highlight_extra
+    hi def link mercuryForeignType  Type
+  else
+    hi def link mercuryForeignType  Normal
+  endif
 endif
 hi def link mercuryDelimiter        Delimiter
 hi def link mercuryPurity           Special
 hi def link mercuryImplKeyword      Identifier
 hi def link mercuryKeyword          Keyword
-hi def link mercuryModelineParam    Identifier
-hi def link mercuryModelineValue    Constant
 hi def link mercuryNumCode          Number
 hi def link mercuryFloat            Float
 hi def link mercuryPragma           PreProc
 hi def link mercuryForeignMod       mercuryForeignIface
 hi def link mercuryForeignOperator  Operator
-hi def link mercuryForeignIface     Identifier
+hi def link mercuryForeignIface     PreProc
 hi def link mercuryImplication      Special
 hi def link mercuryLogical          Special
 hi def link mercuryEscErr           ErrorMsg
 hi def link mercuryErrInAny         ErrorMsg
-hi def link mercuryOperator         Operator
 hi def link mercuryInlined          Operator
-hi def mercuryStabilityLow     ctermfg=red        guifg=red        term=bold
-      \ cterm=bold gui=bold
-hi def mercuryStabilityMedium  ctermfg=darkyellow guifg=darkyellow term=bold
-      \ cterm=bold gui=bold
-hi def mercuryStabilityHigh    ctermfg=darkgreen  guifg=darkgreen  term=bold
-      \ cterm=bold gui=bold
-hi def link mercuryStabilityTo      Delimiter
 hi def link mercuryString           String
 hi def link mercuryStringEsc        Identifier
 hi def link mercuryStringFmt        Special
@@ -687,3 +651,8 @@ hi def link mercuryTooLong          ErrorMsg
 hi def link mercuryWhitespace       mercuryTodo
 hi def link mercuryTerminator       Delimiter
 hi def link mercuryType             Type
+if exists("mercury_highlight_extra") && mercury_highlight_extra
+  hi def link mercuryOperator   Operator
+else
+  hi def link mercuryOperator   Normal
+endif


### PR DESCRIPTION
Use a less obtrusive default highlighting.

vim/doc/mercury.txt:
    Conform to the changes in the *.vim files and fix minor errors.

vim/ftplugin/mercury.vim:
    Make variable underlining optional (uses highlight_extra-flag).
    Make all variables setlocal and key-mappings silent and buffer-local.
    Introduce ,[pftiPMT] and <C-X>[iI] keymappings for rapid typing.

vim/syntax/mercury.vim:
    Folding, special comment constructs, concealing operators, foreign
    types are all disabled by default.
    Increasing synmaxcol from 100 to 250.
    Make ::, :, ^, | delimiters and improve colouring of atomic,
    or_else, trace and require_* keywords.
    Cleanup excessive C(Like)Types.
    Clause head expression now correctly recognise zero-arity functions.
    All special comment highlighting is strictly optional now.