### PR TITLE
Fix moose for more accurate mode checker.

### DIFF
--- a/extras/moose/moose.m
+++ b/extras/moose/moose.m
@@ -579,7 +579,7 @@ gotos(%s, NT, NS) :-
     gotos%s(NT, NS).
 
 :- pred gotos%s(nonterminal, int).
-:- mode gotos%s(in, out) is semidet.
+:- mode gotos%s(in, out(state_no)) is semidet.
 
 ",
             [s(SS), s(SS), s(SS), s(SS)], !IO),


### PR DESCRIPTION
This fixes `write_goto_table/4` in extras/moose/moose.m for the moose
parser generator. The more accurate mode checker requires a more
specific instantiatedness than `ground` for the generated `goto%s/2`
predicates.