### PR TITLE
Update Boehm GC to v7.6.8

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -656,7 +656,7 @@ Changes to the Mercury compiler:
 
 * We have disabled the old --num-reserved-objects option.
 
-* We have upgraded the bundled Boehm GC to v7.6.6 and libatomic_ops to v7.6.2.
+* We have upgraded the bundled Boehm GC to v7.6.8 and libatomic_ops to v7.6.2.
 
 Change to the Mercury debugger:
 

--- a/README.MS-VisualC
+++ b/README.MS-VisualC
@@ -47,27 +47,9 @@ In order to install the C#, Erlang or Java grades you will require a C#,
 Erlang or Java compiler to be included in the Windows PATH.
 (See the relevant README files for further details, e.g. README.Java etc)
 
-
-*** IMPORTANT NOTE FOR USERS OF VISUAL STUDIO 2013 (OR LATER) ***
-
-The Makefile for the Boehm garbage collector requires the files NtWin32.Mak and
-Win32.Mak to be present in the build environment.  These files are *not*
-included with Visual Studio 2013+ and must be copied or included from the
-Windows SDK.  The last version known to provide those files is the Windows 7.1
-SDK.  The need for those files should go away once we update Boehm GC to
-version 7.6.8 (not yet released).
-
-To include the above files, append the SDK directory to the end of the INCLUDE
-environment variable, for example (with the Windows 7.1 SDK):
-
-   C:\> set INCLUDE=%INCLUDE%;C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1a\Include
-
-Alternatively, copy the NtWin32.Mak and Win32.Mak files into the "boehm_gc"
-directory of the Mercury source tree.
-
-Note that boehm_gc/NT_MAKEFILE is hardcoded for the i386 architecture.
-Building for x86_64 will at least require editing of some makefiles.
-This problem can also be resolved once we update Boehm GC to version 7.6.8.
+Note that boehm_gc/NT_MAKEFILE supports both i386 and x64 architectures,
+but the compiler can only target i386 for now. The architecture is controlled
+by the CPU parameter of NT_MAKEFILE.
 
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
As the upstream Boehm GC v7.6.8 is already released for a bit,
Update our fork to that version.
This enables future work on supporting MSVC x64.
See https://github.com/Mercury-Language/bdwgc/pull/1 and
https://github.com/Mercury-Language/bdwgc/pull/2 for the actual changes
in the sub-module.
Those should be merged beforehand as far as I know.

NEWS:
      Announce version change as above.

README.MS-VisualC:
      Remove reference to the Windows SDK v7.1a, as it is not
      required with v7.6.8.
      Change the wording about supported CPU architecture with
      MSVC.

boehm_gc:
      Update tracking branch in boem_gc sub-module.
      Change to the tracking upstream branch is handled in a
      different pull request as this cannot be done in this diff.