### PR TITLE
Fix comment ending a macro

### DIFF
--- a/runtime/mercury_goto.h
+++ b/runtime/mercury_goto.h
@@ -502,7 +502,7 @@
     "   sethi %%hi(_GLOBAL_OFFSET_TABLE_-(0b-.)),%%l7\n"                 \
     "   or %%l7,%%lo(_GLOBAL_OFFSET_TABLE_-(0b-.)),%%l7\n"               \
     "   add %%l7,%%o7,%%l7\n"                                            \
-        // tell gcc we clobber l7, o7, and memory
+        /* tell gcc we clobber l7, o7, and memory */                     \
         : : : "%l7", "%o7", "memory"
 
     // It is safe to fall through into MR_INLINE_ASM_FIXUP_REGS,


### PR DESCRIPTION
runtime/mercury_goto.h:
    Switching one of the comments only seen in Sparc code cut off the end of a macro.
    Only block comments can be placed inside macros anyway, not single-lines.