### PR TITLE
Silence uninitialized value warnings on non-x86/amd64 platforms

### DIFF
--- a/scripts/mgnuc.in
+++ b/scripts/mgnuc.in
@@ -37,7 +37,7 @@ case "$C_COMPILER_TYPE" in
     gcc*)
         ANSI_OPTS="@CFLAGS_FOR_ANSI@"
         CHECK_OPTS="
-            -Wall -Wwrite-strings
+            -Wall -Wwrite-strings -Wno-uninitialized
             -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wno-unused"
 
 # Note: we do not enable the following gcc warnings:
@@ -521,17 +521,6 @@ SANITIZER_OPTS="$CFLAGS_FOR_SANITIZERS"
 
 ARCH_OPTS=""
 case "$FULLARCH" in
-    i*86-*|x86_64*)
-        # The use of stack_pointer in the ASM_JUMP macro defined in
-        # runtime/mercury_goto.h causes lots of warnings about using possibly
-        # uninitialized variables; there's no easy way to suppress them except
-        # by disabling the warning.
-        case "$COMPILER" in
-            gcc)
-                CHECK_OPTS="$CHECK_OPTS -Wno-uninitialized"
-                ;;
-        esac
-        ;;
     *-solaris*|*-sunos*)
         # The solaris headers for pthreads are not ANSI :-(
         case $thread_safe in true)


### PR DESCRIPTION
I have encountered this on OpenBSD on UltraSparc as well as NetBSD on Raspberry Pi 1B.

I began looking into the cases that cause this error (see here: https://github.com/AlaskanEmily/mercury/commit/f8fe24e5e94ad2301cc584a6c244a27c911f4c5a ). I found all the cases in the runtime were false-positives. Older GCC (4.8, which is egcc on OpenBSD) was also giving this warning with mmc-generated C code, so I would think it's sensible to just silence the warning on all platforms?