### PR TITLE
Fix using MSVC to compile mmc

### DIFF
--- a/scripts/mgnuc.in
+++ b/scripts/mgnuc.in
@@ -523,8 +523,8 @@ ARCH_OPTS=""
 
 # XXX gcc generates warnings about possibly uninitialized variables in
 # high-level C code. clang would, too, if we did not suppress all warnings.
-case "$highlevel_code" in
-    true)
+case "$COMPILER,$highlevel_code" in
+    gcc,true)
         CHECK_OPTS="$CHECK_OPTS -Wno-uninitialized"
         ;;
 esac


### PR DESCRIPTION
The new -Wno-uninitialized options added for high-level C did not check for gcc.
I added a compiler check in the same way as it is done if the platform is x86/amd64.