### PR TITLE
Hashing-related fixes

### DIFF
--- a/library/hash_table.m
+++ b/library/hash_table.m
@@ -820,7 +820,7 @@ uint_hash(!.Key, Hash) :-
     else
         !:Key = (\ !.Key) + (!.Key << 21), % !:Key = (!.Key << 21) - !.Key - 1
         !:Key = !.Key `xor` (!.Key >> 24),
-        !:Key = (!.Key + (!.Key << 3)) + (!.Key << 8), % !.Key * 245
+        !:Key = (!.Key + (!.Key << 3)) + (!.Key << 8), % !.Key * 265
         !:Key = !.Key `xor` (!.Key >> 14),
         !:Key = (!.Key + (!.Key << 2)) + (!.Key << 4), % !.Key * 21
         !:Key = !.Key `xor` (!.Key >> 28),

--- a/library/string.m
+++ b/library/string.m
@@ -2929,7 +2929,7 @@ hash2_loop(String, Index, Length, !HashVal) :-
     ( if Index < Length then
         unsafe_index_code_unit(String, Index, C),
         !:HashVal = !.HashVal * 37,
-        !:HashVal= !.HashVal + C,
+        !:HashVal = !.HashVal + C,
         hash2_loop(String, Index + 1, Length, !HashVal)
     else
         true
@@ -2947,7 +2947,7 @@ hash3_loop(String, Index, Length, !HashVal) :-
     ( if Index < Length then
         unsafe_index_code_unit(String, Index, C),
         !:HashVal = !.HashVal * 49,
-        !:HashVal= !.HashVal + C,
+        !:HashVal = !.HashVal + C,
         hash3_loop(String, Index + 1, Length, !HashVal)
     else
         true
@@ -2988,7 +2988,7 @@ hash5_loop(String, Index, Length, !HashVal) :-
     ( if Index < Length then
         unsafe_index_code_unit(String, Index, C),
         !:HashVal = keep_30_bits(!.HashVal * 37),
-        !:HashVal= keep_30_bits(!.HashVal + C),
+        !:HashVal = keep_30_bits(!.HashVal + C),
         hash5_loop(String, Index + 1, Length, !HashVal)
     else
         true
@@ -3006,7 +3006,7 @@ hash6_loop(String, Index, Length, !HashVal) :-
     ( if Index < Length then
         unsafe_index_code_unit(String, Index, C),
         !:HashVal = keep_30_bits(!.HashVal * 49),
-        !:HashVal= keep_30_bits(!.HashVal + C),
+        !:HashVal = keep_30_bits(!.HashVal + C),
         hash6_loop(String, Index + 1, Length, !HashVal)
     else
         true

--- a/library/string.m
+++ b/library/string.m
@@ -2971,7 +2971,7 @@ hash4_loop(String, Index, Length, !HashVal) :-
         !:HashVal = keep_30_bits(!.HashVal `xor`
             (!.HashVal `unchecked_left_shift` 5)),
         !:HashVal = !.HashVal `xor` C,
-        hash_loop(String, Index + 1, Length, !HashVal)
+        hash4_loop(String, Index + 1, Length, !HashVal)
     else
         true
     ).

--- a/library/string.m
+++ b/library/string.m
@@ -2892,10 +2892,8 @@ codepoint_offset(String, N, Index) :-
 %
 % Computing hashes of strings.
 %
-%
-% NOTE: hash, hash2 and hash3 are also defined as MR_hash_string,
-% MR_hash_string2 and MR_hash_string3 in runtime/mercury_string.h.
-% The corresponding definitions must be kept identical.
+% Note that these functions are also defined in runtime/mercury_string.h.
+% The definition here and in mercury_string.h must be kept equivalent.
 %
 
 hash(String) = HashVal :-

--- a/runtime/mercury_string.h
+++ b/runtime/mercury_string.h
@@ -194,13 +194,14 @@
         (ptr) = make_aligned_string_ptr;                                \
     } while (0)
 
-// MR_do_hash_string{,2,3}(int & hash, MR_Word string):
+// MR_do_hash_string{,2,3,4,5,6}(int & hash, MR_Word string):
 //
 // Given a Mercury string `string', set `hash' to the hash value
 // for that string. (`hash' must be an lvalue.)
 //
-// This is an implementation detail used to implement MR_hash_string{,2,3}().
-// It should not be used directly. Use MR_hash_string{,2,3}() instead.
+// This is an implementation detail used to implement
+// MR_hash_string{,2,3,4,5,6}(). It should not be used directly.
+// Use MR_hash_string{,2,3,4,5,6}() instead.
 //
 // Note that these functions are also defined in library/string.m.
 // The definition here and in string.m must be kept equivalent.
@@ -292,7 +293,7 @@
         hash ^= i;                                                          \
     }
 
-// MR_hash_string{,2,3}(s):
+// MR_hash_string{,2,3,4,5,6}(s):
 //
 // Given a Mercury string `s', return a hash value for that string.
 

--- a/tests/hard_coded/string_hash.m
+++ b/tests/hard_coded/string_hash.m
@@ -1,8 +1,12 @@
 % vim: ts=4 sw=4 et ft=mercury
 
 % Test that string.hash and MR_hash_string return the same value.
-% Do the same for string.hash2 and MR_hash_string2, and for
-% string.hash3 and MR_hash_string3.
+% Do the same for:
+% * string.hash2 and MR_hash_string2,
+% * string.hash3 and MR_hash_string3,
+% * string.hash4 and MR_hash_string4,
+% * string.hash5 and MR_hash_string5,
+% * string.hash6 and MR_hash_string6.
 
 :- module string_hash.
 
@@ -46,48 +50,27 @@ test(Length, !Succeeded, !RS, !IO) :-
 
         LibHash1 = string.hash(String),
         RuntimeHash1 = runtime_string_hash(String),
-        ( LibHash1 = RuntimeHash1 ->
-            true
-        ;
-            !:Succeeded = no,
-            io.write_string("failed hash1: runtime ", !IO),
-            io.write_int(RuntimeHash1, !IO),
-            io.write_string(", library ", !IO),
-            io.write_int(LibHash1, !IO),
-            io.write_string(": """, !IO),
-            io.write_string(String, !IO),
-            io.write_string("""\n", !IO)
-        ),
+        test_hash("hash1", LibHash1, RuntimeHash1, String, !Succeeded, !IO),
 
         LibHash2 = string.hash2(String),
         RuntimeHash2 = runtime_string_hash2(String),
-        ( LibHash2 = RuntimeHash2 ->
-            true
-        ;
-            !:Succeeded = no,
-            io.write_string("failed hash2: runtime ", !IO),
-            io.write_int(RuntimeHash2, !IO),
-            io.write_string(", library ", !IO),
-            io.write_int(LibHash2, !IO),
-            io.write_string(": """, !IO),
-            io.write_string(String, !IO),
-            io.write_string("""\n", !IO)
-        ),
+        test_hash("hash2", LibHash2, RuntimeHash2, String, !Succeeded, !IO),
 
         LibHash3 = string.hash3(String),
         RuntimeHash3 = runtime_string_hash3(String),
-        ( LibHash3 = RuntimeHash3 ->
-            true
-        ;
-            !:Succeeded = no,
-            io.write_string("failed hash3: runtime ", !IO),
-            io.write_int(RuntimeHash3, !IO),
-            io.write_string(", library ", !IO),
-            io.write_int(LibHash3, !IO),
-            io.write_string(": """, !IO),
-            io.write_string(String, !IO),
-            io.write_string("""\n", !IO)
-        ),
+        test_hash("hash3", LibHash3, RuntimeHash3, String, !Succeeded, !IO),
+
+        LibHash4 = string.hash4(String),
+        RuntimeHash4 = runtime_string_hash4(String),
+        test_hash("hash4", LibHash4, RuntimeHash4, String, !Succeeded, !IO),
+
+        LibHash5 = string.hash5(String),
+        RuntimeHash5 = runtime_string_hash5(String),
+        test_hash("hash5", LibHash5, RuntimeHash5, String, !Succeeded, !IO),
+
+        LibHash6 = string.hash6(String),
+        RuntimeHash6 = runtime_string_hash6(String),
+        test_hash("hash6", LibHash6, RuntimeHash6, String, !Succeeded, !IO),
 
         test(Length - 1, !Succeeded, !RS, !IO)
     ).
@@ -111,6 +94,23 @@ rand_char(Char, !RS) :-
     % U+0001..U+10ffff (avoid null character).
     Int = 1 + (Rand `mod` char.max_char_value),
     char.det_from_int(Int, Char).
+
+:- pred test_hash(string::in, int::in, int::in, string::in,
+    bool::in, bool::out, io::di, io::uo) is det.
+
+test_hash(HashName, LibHash, RuntimeHash, String, !Succeeded, !IO) :-
+    ( LibHash = RuntimeHash ->
+        true
+    ;
+        !:Succeeded = no,
+        io.write_string("failed " ++ HashName ++ ": runtime ", !IO),
+        io.write_int(RuntimeHash, !IO),
+        io.write_string(", library ", !IO),
+        io.write_int(LibHash, !IO),
+        io.write_string(": """, !IO),
+        io.write_string(String, !IO),
+        io.write_string("""\n", !IO)
+    ).
 
 :- pragma foreign_decl("C", "#include ""mercury_string.h""").
 
@@ -139,4 +139,31 @@ rand_char(Char, !RS) :-
     [promise_pure, will_not_call_mercury],
 "
     Hash = MR_hash_string3(StringArg);
+").
+
+:- func runtime_string_hash4(string) = int.
+
+:- pragma foreign_proc("C",
+    runtime_string_hash4(StringArg::in) = (Hash::out),
+    [promise_pure, will_not_call_mercury],
+"
+    Hash = MR_hash_string4(StringArg);
+").
+
+:- func runtime_string_hash5(string) = int.
+
+:- pragma foreign_proc("C",
+    runtime_string_hash5(StringArg::in) = (Hash::out),
+    [promise_pure, will_not_call_mercury],
+"
+    Hash = MR_hash_string5(StringArg);
+").
+
+:- func runtime_string_hash6(string) = int.
+
+:- pragma foreign_proc("C",
+    runtime_string_hash6(StringArg::in) = (Hash::out),
+    [promise_pure, will_not_call_mercury],
+"
+    Hash = MR_hash_string6(StringArg);
 ").


### PR DESCRIPTION
This PR:

* Updates some string-hashing-related comments.
* Fixes a comment in `hash_table.uint_hash`. `(k + (k << 3)) + (k << 8)` should be equivalent to `k * 265`, not `k * 245`.
* Fixes minor formatting issues in `string.hash{2,3,5,6}_loop` predicates.
* Fixes a bug in `string.hash4_loop`, where the predicate wasn't calling itself on the recursive step.
* Adds tests for `string.hash{4,5,6}`.