### PR TITLE
Fix people link in RELEASE_NOTES

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -211,4 +211,4 @@ The home page of the project on the Web is:
     <http://www.mercurylang.org>.
 
 --
-The Mercury Team <http://www.mercurylang.org/contact/people.html>
+The Mercury Team <http://www.mercurylang.org/development/people.html>


### PR DESCRIPTION
It may also be worth running through and changing all the links to https, but I figured that was out of scope.