### PR TITLE
Fix builds on macOS

### DIFF
--- a/runtime/mercury_memory_handlers.c
+++ b/runtime/mercury_memory_handlers.c
@@ -61,7 +61,7 @@
     static void         complex_bushandler(int, siginfo_t *, void *);
     static void         complex_segvhandler(int, siginfo_t *, void *);
   #else
-    #error "MR_HAVE_SIGINFO defined but don't know how to get it"
+    static void         simple_sighandler(int);
   #endif
 #else
   static void           simple_sighandler(int);
@@ -80,7 +80,8 @@
     #define     bus_handler     complex_bushandler
     #define     segv_handler    complex_segvhandler
   #else
-    #error "MR_HAVE_SIGINFO defined but don't know how to get it"
+    #define     bus_handler     simple_sighandler
+    #define     segv_handler    simple_sighandler
   #endif
 #else
     #define     bus_handler     simple_sighandler


### PR DESCRIPTION
I'm a maintainer for Homebrew, and in the process of packaging openjdk have noticed that mercury fails to build from source on newer Xcode versions with clang.

This patch addresses the issue where `MR_HAVE_SIGINFO_T` is defined but `MR_HAVE_SIGINFO` isn't. in this case, the memory system should use simple signal handlers rather than reporting an error at compile-time.

I think the root cause of this issue is a broken autoconf macro. `MR_HAVE_SIGINFO` appears to be defined in an unrelated check. In addition, endianness detection seems to be broken on macOS. I don't really want to dig into autoconf macros so I've fixed it by tricking configure into thinking it's already checked for that. I note that autoconf already ships with an endian detection macro, `AC_C_BIGENDIAN`.

c.f. https://github.com/Homebrew/homebrew-core/pull/62606