### PR TITLE
Fix a bug where valid code points were treated like invalid surrogates.

### DIFF
--- a/runtime/mercury_string.h
+++ b/runtime/mercury_string.h
@@ -425,7 +425,7 @@ extern MR_bool MR_escape_string_quote(MR_String *ptr,
 
 // True if c is a Unicode surrogate code point, i.e. U+D800..U+DFFF.
 
-#define MR_is_surrogate(c)          (((unsigned) (c) & 0xF800) == 0xD800)
+#define MR_is_surrogate(c)          (((unsigned) (c) & 0x1FF800) == 0xD800)
 
 // True if c is a Unicode control code point, i.e. U+0000..U+001f,
 // U+007f..U+009f.

--- a/tests/hard_coded/Mmakefile
+++ b/tests/hard_coded/Mmakefile
@@ -54,6 +54,7 @@ ORDINARY_PROGS = \
 	cc_multi_bug \
 	cc_nondet_disj \
 	change_hunk_test \
+	char_not_surrogate \
 	char_signed \
 	char_unicode \
 	checked_nondet_tailcall \
@@ -385,6 +386,7 @@ ORDINARY_PROGS = \
 	string_index_ilseq \
 	string_index_next_ilseq \
 	string_loop \
+	string_not_surrogate \
 	string_presuffix \
 	string_prev_index_ilseq \
 	string_set_char \

--- a/tests/hard_coded/char_not_surrogate.exp
+++ b/tests/hard_coded/char_not_surrogate.exp
@@ -1,0 +1,4 @@
+code point: 0x01d800
+code point: 0x01dfff
+code point: 0x10d800
+code point: 0x10dfff

--- a/tests/hard_coded/char_not_surrogate.m
+++ b/tests/hard_coded/char_not_surrogate.m
@@ -1,0 +1,40 @@
+%---------------------------------------------------------------------------%
+% vim: ts=4 sw=4 et ft=mercury
+%---------------------------------------------------------------------------%
+
+:- module char_not_surrogate.
+:- interface.
+
+:- import_module io.
+
+:- pred main(io::di, io::uo) is det.
+
+%---------------------------------------------------------------------------%
+%---------------------------------------------------------------------------%
+
+:- implementation.
+
+:- import_module char.
+:- import_module list.
+:- import_module string.
+
+%---------------------------------------------------------------------------%
+
+main(!IO) :-
+    Chars = [
+        '\U0001D800',
+        '\U0001DFFF',
+        '\U0010D800',
+        '\U0010DFFF'
+    ],
+    list.foldl(test, Chars, !IO).
+
+:- pred test(char::in, io::di, io::uo) is det.
+
+test(Char, !IO) :-
+    io.write_string("code point: ", !IO),
+    Int = char.to_int(Char),
+    io.format("0x%06x", [i(Int)], !IO),
+    io.nl(!IO).
+
+%---------------------------------------------------------------------------%

--- a/tests/hard_coded/string_not_surrogate.exp
+++ b/tests/hard_coded/string_not_surrogate.exp
@@ -1,0 +1,2 @@
+code points: 0x01d800, 0x01dfff
+code points: 0x10d800, 0x10dfff

--- a/tests/hard_coded/string_not_surrogate.m
+++ b/tests/hard_coded/string_not_surrogate.m
@@ -1,0 +1,44 @@
+%---------------------------------------------------------------------------%
+% vim: ts=4 sw=4 et ft=mercury
+%---------------------------------------------------------------------------%
+
+:- module string_not_surrogate.
+:- interface.
+
+:- import_module io.
+
+:- pred main(io::di, io::uo) is det.
+
+%---------------------------------------------------------------------------%
+%---------------------------------------------------------------------------%
+
+:- implementation.
+
+:- import_module char.
+:- import_module list.
+:- import_module string.
+
+%---------------------------------------------------------------------------%
+
+main(!IO) :-
+    Strings = [
+        "\U0001D800\U0001DFFF",
+        "\U0010D800\U0010DFFF"
+    ],
+    list.foldl(test, Strings, !IO).
+
+:- pred test(string::in, io::di, io::uo) is det.
+
+test(String, !IO) :-
+    io.write_string("code points: ", !IO),
+    Chars = string.to_char_list(String),
+    Ints = list.map(char.to_int, Chars),
+    io.write_list(Ints, ", ", write_hex_int, !IO),
+    io.nl(!IO).
+
+:- pred write_hex_int(int::in, io::di, io::uo) is det.
+
+write_hex_int(Int, !IO) :-
+    io.format("0x%06x", [i(Int)], !IO).
+
+%---------------------------------------------------------------------------%


### PR DESCRIPTION
runtime/mercury_string.h:

As above. Valid code points in the ranges [1D800, 1DFFF] and [10D800, 10DFFF] were treated like invalid surrogates because the high bits were masked away.

Minimal reproduction using rotd-2021-10-21:

```mercury
:- module test.
:- interface.

:- import_module io.

:- pred main(io::di, io::uo) is det.

:- implementation.

main(!IO) :-
    % $ mmc test.m
    %
    % test.m:015: In clause for predicate `main'/2:
    % test.m:015:   error: undefined symbol `𝠀'/0.
    _ = '\U0001D800',
    % No compilation error, but prints "����".
    io.write_string("\U0001D800\n", !IO).
```