### PR TITLE
Use autoconf macro to search for strip command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1168,18 +1168,20 @@ else
     ARFLAGS="cr"
     AR_LIBFILE_OPT=""
 
-    LD_STRIP_FLAG="-s"
-    STRIP_EXE=""
-    STRIP_EXE_SHARED_FLAGS=""
-    STRIP_EXE_STATIC_FLAGS=""
-
-    # The `-s' linker option is deprecated on Darwin 9+ and has no effect other
-    # than causing the linker to emit a warning. Call the strip tool directly.
     case "$host" in
         *apple*darwin*)
+            # The `-s' linker option is deprecated on Darwin 9+ and has no
+            # effect other than causing the linker to emit a warning. Call the
+            # strip tool directly.
             LD_STRIP_FLAG=""
-            STRIP_EXE="strip"
+            AC_CHECK_TOOL([STRIP_EXE], [strip], [strip])
             STRIP_EXE_SHARED_FLAGS="-x"
+            STRIP_EXE_STATIC_FLAGS=""
+            ;;
+        *)
+            LD_STRIP_FLAG="-s"
+            STRIP_EXE=""
+            STRIP_EXE_SHARED_FLAGS=""
             STRIP_EXE_STATIC_FLAGS=""
             ;;
     esac


### PR DESCRIPTION
This uses the [`AC_CHECK_TOOL`](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/html_node/Generic-Programs.html#index-AC_005fCHECK_005fTOOL-1) macro to search for the strip command on Darwin. This is more consistent with how the other tools are configured, for example `ar` and `nm`, and allows it to be overridden if necessary.