### PR TITLE
Fix install of extras/net

### DIFF
--- a/extras/net/Makefile
+++ b/extras/net/Makefile
@@ -26,6 +26,10 @@ test_lookups: Mercury.modules
 Mercury.modules: $(MERCURY_FILES)
 	$(MMC) -f $(MERCURY_FILES)
 
+.PHONY: install
+install:
+	$(MMC) $(MMCFLAGS) --make libnet.install
+
 tags: $(MERCURY_FILES)
 	$(MTAGS) $(MERCURY_FILES)
 

--- a/extras/net/Mercury.options
+++ b/extras/net/Mercury.options
@@ -5,6 +5,6 @@
 EXTRA_CFLAGS=-D_BSD_SOURCE=1 -D_DEFAULT_SOURCE=1
 
 # Workaround a bug in Mercury's pack bits optimisation.
-MCFLAGS=--arg-pack-bits 0
-
-
+MCFLAGS=--arg-pack-bits 0 \
+	--libgrades-exclude java \
+	--libgrades-exclude csharp

--- a/extras/net/netdb.m
+++ b/extras/net/netdb.m
@@ -112,12 +112,11 @@
 "
 #ifdef MR_WIN32
   #define  error()      WSAGetLastError()
-
-#ifdef MR_THREAD_SAFE
-  static MercuryLock    lookup_lock = MR_MUTEX_ATTR;
-#endif
 #else
   #define  error()      errno
+#endif
+#ifdef MR_THREAD_SAFE
+  static MercuryLock    lookup_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif
 ").
 
@@ -169,7 +168,7 @@ getprotobyname(Name, MaybeProtocol, !IO) :-
     int             i;
 
     #ifdef MR_THREAD_SAFE
-      MR_LOCK(lookup_lock, ""getprotobyname_r"");
+      MR_LOCK(&lookup_lock, ""getprotobyname_r"");
     #endif
 
     temp = getprotobyname(Name);
@@ -190,7 +189,7 @@ getprotobyname(Name, MaybeProtocol, !IO) :-
     Success = MR_YES;
 
     #ifdef MR_THREAD_SAFE
-      MR_UNLOCK(lookup_lock, ""getprotobyname_r"");
+      MR_UNLOCK(&lookup_lock, ""getprotobyname_r"");
     #endif
 
 #endif /* ! __GNU_LIBRARY__ */


### PR DESCRIPTION
I preferred this to extras/posix because it supports IPv6. I've tested it on macOS

Although the use of PTHREAD_MUTEX_INITIALIZER is correct, it may not fit the desired style. Could introduce a #define alongside MR_MUTEX_ATTR if preferred. 