### PR TITLE
Fix --no-warn-non-contiguous-decls documentation.

### DIFF
--- a/compiler/options.m
+++ b/compiler/options.m
@@ -4259,7 +4259,7 @@ options_help_warning(Stream, !IO) :-
         "\tand functions of the module, or for the nonexported predicates",
         "\tand functions of the module. Applies for definitions by either",
         "\tMercury clauses or foreign_proc pragmas.",
-        "--no-warn-non-contiguous-decl",
+        "--no-warn-non-contiguous-decls",
         "\tDo not generate a warning if the mode declarations of a",
         "\tpredicate or function don't all immediately follow its",
         "\tpredicate or function declaration.",

--- a/doc/user_guide.texi
+++ b/doc/user_guide.texi
@@ -6753,8 +6753,8 @@ and functions of the module. Applies for definitions by either
 Mercury clauses or foreign_proc pragmas.
 
 @sp 1
-@item --no-warn-non-contiguous-decl
-@findex --no-warn-non-contiguous-decl
+@item --no-warn-non-contiguous-decls
+@findex --no-warn-non-contiguous-decls
 Do not generate a warning if the mode declarations of a
 predicate or function don't all immediately follow its
 predicate or function declaration.


### PR DESCRIPTION
doc/user_guide.texi:
compiler/options.m:
    Name the option correctly in the documentation.