### PR TITLE
Mark switch as complete in is_foreign_type_body_for_target

### DIFF
--- a/compiler/du_type_layout.m
+++ b/compiler/du_type_layout.m
@@ -4045,6 +4045,7 @@ module_visibilities_allow_direct_arg(TypeStatus, ArgCond) = AllowDirectArg :-
     compilation_target::in, foreign_type_assertions::out) is semidet.
 
 is_foreign_type_body_for_target(ForeignType, Target, Assertions) :-
+    require_complete_switch [Target]
     (
         Target = target_c,
         ForeignType ^ c = yes(type_details_foreign(_, _, Assertions))


### PR DESCRIPTION
Since du_type_layout.is_foreign_type_body_for_target is semidet, we won't get any compilation error when adding a new target, and it will fail at runtime. Fix this by marking the switch on Target as complete.