### PR TITLE
Support targeting Windows on ARM64 with MSVC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Mercury repository line-ending policy.
+#
+# Default: treat all detected text files as text, normalize to LF in the
+# index, and check out with LF in the working tree. This prevents Windows
+# checkouts (with core.autocrlf=true) from injecting CRLF into shell
+# scripts, .mgnuc_opts files, configure scripts, Mercury sources, etc.
+# Shell-script-style consumers (e.g. scripts/mgnuc reading .mgnuc_opts)
+# break when CRLF leaks in, so LF-everywhere is the safe default.
+* text=auto eol=lf
+
+# Binary files: skip all normalization.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.pdf  binary

--- a/Documentation/README.MS-VisualC.md
+++ b/Documentation/README.MS-VisualC.md
@@ -4,10 +4,10 @@ Mercury with Microsoft Visual C++
 This file documents the port of Mercury to Windows that uses Microsoft Visual
 C++ (MSVC) as a C compiler.
 
-With MSVC, you can install a Mercury compiler that generates either x86
-(32-bit) or x64 (64-bit) Windows native code in C grades, but not both.
-(You can, of course, have multiple Mercury installations that use MSVC,
-and have one that targets x86 and another that targets x64.)
+With MSVC, you can install a Mercury compiler that generates x86 (32-bit),
+x64 (64-bit), or ARM64 Windows native code in C grades, but only one per
+installation. (You can, of course, have multiple Mercury installations that
+use MSVC, each targeting a different architecture.)
 
 Contents
 --------
@@ -47,13 +47,20 @@ following:
        Start Menu
        └── Visual Studio 2022
            ├── x64 Native Tools Command Prompt for VS 2022
-           └── x86 Native Tools Command Prompt for VS 2022
+           ├── x86 Native Tools Command Prompt for VS 2022
+           └── ARM64 Native Tools Command Prompt for VS 2022
 
-   Select x64 to target 64-bit Windows or x86 to target 32-bit Windows.
+   Select x64 to target 64-bit Windows, x86 to target 32-bit Windows, or
+   ARM64 to target Windows on ARM64.
 
    If you prefer not to use the Start Menu shortcuts, then you can manually set
    up the environment variables by running one of the batch files supplied with
-   Visual Studio (e.g. `vcvars32.bat` for x86, `vcvars64.bat` for x64).
+   Visual Studio (e.g. `vcvars32.bat` for x86, `vcvars64.bat` for x64,
+   `vcvarsarm64.bat` for ARM64).
+
+   To install the ARM64 port, your Visual Studio installation needs the
+   "MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools" individual component
+   (in addition to "Desktop development with C++").
 
 2. Start the MSYS2 shell using this command:
 

--- a/Documentation/README.MSYS2.md
+++ b/Documentation/README.MSYS2.md
@@ -168,6 +168,26 @@ all other MSYS2 environments. A common problem is accidentally using the `MSYS`
 compilers. This happens if you forgot to install the compiler package for your
 specific environment (e.g. `UCRT64`).
 
+### Readline Library
+
+The Mercury debugger (`mdb`) links to GNU readline if `configure` detects it.
+Because the `readline` package shipped in the `MSYS` environment is visible
+on the `PATH` of every other MSYS2 environment, `configure` will detect a
+copy that is not usable for linking from `UCRT64`, `MINGW64`, `MINGW32`,
+`CLANG64` or `CLANGARM64`, and the build will then fail in
+`mercury_trace_readline.c`. To avoid this, either install the readline
+package matching your chosen environment via `pacman`, or pass
+`--without-readline` to `configure`. For example, for `CLANGARM64`:
+
+    pacman -S mingw-w64-clang-aarch64-readline
+
+The corresponding packages for the other environments are
+`mingw-w64-clang-x86_64-readline` (`CLANG64`),
+`mingw-w64-ucrt-x86_64-readline` (`UCRT64`),
+`mingw-w64-x86_64-readline` (`MINGW64`),
+`mingw-w64-i686-readline` (`MINGW32`),
+and `readline` (`MSYS`).
+
 ### Documentation Packages
 
 To build the Mercury documentation, you need the following packages:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1954,8 +1954,9 @@ Changes to the Mercury implementation
 Portability improvements
 ------------------------
 
-* We now support using the 64-bit (i.e. x64) version of Microsoft Visual C++
-  as a C compiler with Mercury.
+* We now support using the 64-bit (x64) and ARM64 versions of Microsoft Visual
+  C++ as a C compiler with Mercury, including building Mercury installations
+  targeting Windows on ARM64.
   See [README.MS-VisualC.md](Documentation/README.MS-VisualC.md) for further
   details.
 

--- a/compiler/check_options.m
+++ b/compiler/check_options.m
@@ -351,6 +351,7 @@ check_system_env_options(OptionTable, C_CompilerType, CSharp_CompilerType,
             "clang",
             "msvc_x86",
             "msvc_x64",
+            "msvc_arm64",
             "unknown"
         ],
         CCTpec =

--- a/compiler/compile_target_code.m
+++ b/compiler/compile_target_code.m
@@ -360,6 +360,7 @@ gather_c_compiler_flags(Globals, PIC, AllCFlags) :-
             % XXX Check whether we need to do anything for these C compilers?
             ( C_CompilerType = cc_cl_x86(_)
             ; C_CompilerType = cc_cl_x64(_)
+            ; C_CompilerType = cc_cl_arm64(_)
             ),
             C_FnAlignOpt = ""
         ;
@@ -496,6 +497,7 @@ gather_specific_c_compiler_flags(Globals, Flags) :-
     ;
         ( C_CompilerType = cc_cl_x86(_)
         ; C_CompilerType = cc_cl_x64(_)
+        ; C_CompilerType = cc_cl_arm64(_)
         ),
         globals.lookup_accumulating_option(Globals, msvc_flags, FlagsList)
     ;

--- a/compiler/globals.m
+++ b/compiler/globals.m
@@ -169,6 +169,7 @@
     ;       cc_clang(maybe(clang_version))
     ;       cc_cl_x86(maybe(int))  % MSVC targeting x86.
     ;       cc_cl_x64(maybe(int))  % MSVC targeting x86_64 (x64).
+    ;       cc_cl_arm64(maybe(int))  % MSVC targeting ARM64 (aarch64).
     ;       cc_unknown.
 
 :- type clang_version
@@ -682,6 +683,7 @@ convert_c_compiler_type_simple("clang",    cc_clang(no)).
 convert_c_compiler_type_simple("msvc",     cc_cl_x86(no)).
 convert_c_compiler_type_simple("msvc_x86", cc_cl_x86(no)).
 convert_c_compiler_type_simple("msvc_x64", cc_cl_x64(no)).
+convert_c_compiler_type_simple("msvc_arm64", cc_cl_arm64(no)).
 convert_c_compiler_type_simple("unknown",  cc_unknown).
 
 :- pred convert_c_compiler_type_with_version(string::in, c_compiler_type::out)
@@ -701,6 +703,8 @@ convert_c_compiler_type_with_version(CC_Str, C_CompilerType) :-
         convert_msvc_x86_version(Version, C_CompilerType)
     else if Tokens = ["msvc", "x64", Version] then
         convert_msvc_x64_version(Version, C_CompilerType)
+    else if Tokens = ["msvc", "arm64", Version] then
+        convert_msvc_arm64_version(Version, C_CompilerType)
     else
         false
     ).
@@ -797,6 +801,13 @@ convert_msvc_x64_version(VersionStr, C_CompilerType) :-
     string.to_int(VersionStr, Version),
     Version > 0,
     C_CompilerType = cc_cl_x64(yes(Version)).
+
+:- pred convert_msvc_arm64_version(string::in, c_compiler_type::out) is semidet.
+
+convert_msvc_arm64_version(VersionStr, C_CompilerType) :-
+    string.to_int(VersionStr, Version),
+    Version > 0,
+    C_CompilerType = cc_cl_arm64(yes(Version)).
 
 convert_csharp_compiler_type("microsoft", csharp_microsoft).
 convert_csharp_compiler_type("mono", csharp_mono).

--- a/compiler/link_target_code.m
+++ b/compiler/link_target_code.m
@@ -619,6 +619,7 @@ get_reserve_stack_size_flags_for_c(Globals) = Flags :-
         ;
             ( C_CompilerType = cc_cl_x86(_)
             ; C_CompilerType = cc_cl_x64(_)
+            ; C_CompilerType = cc_cl_arm64(_)
             ),
             string.format("-stack:%d", [i(ReserveStackSize)], Flags)
         )
@@ -960,6 +961,18 @@ get_restricted_command_line_link_opts_for_c(Globals, LinkedTargetType,
                 join_string_list(RestrictedCmdLinkFlags, "", "", " ",
                     RestrictedCmdLinkOpts)
             ;
+                C_CompilerType = cc_cl_arm64(_),
+                RestrictedCmdLinkFlags = [
+                    "-nologo",
+                    "-ignore:4001",
+                    "-subsystem:console",
+                    "-machine:arm64",
+                    "-entry:wmainCRTStartup",
+                    "-defaultlib:libcmt"
+                ],
+                join_string_list(RestrictedCmdLinkFlags, "", "", " ",
+                    RestrictedCmdLinkOpts)
+            ;
                 ( C_CompilerType = cc_gcc(_, _, _)
                 ; C_CompilerType = cc_clang(_)
                 ; C_CompilerType = cc_unknown
@@ -1076,6 +1089,7 @@ get_linker_output_option_for_c(Globals, LinkedTargetType, OutputOpt) :-
     (
         ( C_CompilerType = cc_cl_x86(_)
         ; C_CompilerType = cc_cl_x64(_)
+        ; C_CompilerType = cc_cl_arm64(_)
         ),
         ( if LinkedTargetType = executable then
             % NOTE: -Fe _must not_ be separated from its argument by any
@@ -1211,6 +1225,7 @@ create_archive_for_c(Globals, ProgressStream, FullLibFileName, Quote,
         % lib tool.
         ( C_CompilerType = cc_cl_x86(_)
         ; C_CompilerType = cc_cl_x64(_)
+        ; C_CompilerType = cc_cl_arm64(_)
         ),
         ArOutputSpace = ""
     ;
@@ -1674,6 +1689,7 @@ get_link_opts_for_library_for_c_cs(Globals, LibName, LinkerOpt,
         ;
             ( CCompilerType = cc_cl_x86(_)
             ; CCompilerType = cc_cl_x64(_)
+            ; CCompilerType = cc_cl_arm64(_)
             ),
             LinkOpt = "",
             LibSuffix = ".lib"

--- a/compiler/options.m
+++ b/compiler/options.m
@@ -4573,7 +4573,7 @@ optdb(oc_target_c,  cc,                                string("gcc"),
         w("Specify which C compiler to use.")])).
 optdb(oc_target_c,  c_compiler_type,                   string("gcc"),
     priv_arg_help("c-compiler-type",
-        "{gcc,clang,msvc_x86,msvc_x64,unknown}", [])).
+        "{gcc,clang,msvc_x86,msvc_x64,msvc_arm64,unknown}", [])).
     % The `mmc' script will override the default with a value
     % determined at configuration time for the above two options.
     % XXX That argues for this option being oc_config.

--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,7 @@ case "$mercury_cv_cc_type" in
         C_COMPILER_TYPE="gcc_${mercury_cv_gcc_version}"
         ;;
 
-    msvc_x86|msvc_x64)
+    msvc_x86|msvc_x64|msvc_arm64)
         MERCURY_HAVE_MSVC=yes
         MERCURY_MSVC_VERSION
         C_COMPILER_TYPE="${mercury_cv_cc_type}_${mercury_cv_msvc_version}"
@@ -206,6 +206,7 @@ esac
 
 case "$mercury_cv_cc_type" in
     msvc_x64) BOEHM_WINDOWS_CPU_TYPE="x64" ;;
+    msvc_arm64) BOEHM_WINDOWS_CPU_TYPE="ARM64" ;;
     *) BOEHM_WINDOWS_CPU_TYPE="x86" ;;
 esac
 

--- a/m4/mercury.m4
+++ b/m4/mercury.m4
@@ -642,6 +642,8 @@ int main(int argc, char **argv)
           printf("msvc_x86");
        #elif defined(_M_X64)
           printf("msvc_x64");
+       #elif defined(_M_ARM64)
+          printf("msvc_arm64");
        #else
           printf("unknown");
        #endif

--- a/tests/warnings/help_text.err_exp
+++ b/tests/warnings/help_text.err_exp
@@ -2650,7 +2650,7 @@ Options for target language compilation
         Specify which C compiler to use.
 
     PRIVATE OPTION
-    --c-compiler-type {gcc,clang,msvc_x86,msvc_x64,unknown}
+    --c-compiler-type {gcc,clang,msvc_x86,msvc_x64,msvc_arm64,unknown}
         There is no help text available.
 
     --c-optimize


### PR DESCRIPTION
Extend the MSVC port to cover ARM64 (aarch64) in addition to x86 and x64.

Detect `_M_ARM64` at configure time, add a `cc_cl_arm64` constructor to
the `c_compiler_type` type in `compiler/globals.m`, and thread it through
every site that already pattern-matches on `cc_cl_x86`/`cc_cl_x64` in the
compiler. In `get_restricted_command_line_link_opts_for_c`, add an arm64
case that passes `-machine:arm64` to the linker. Map `msvc_arm64` to
`BOEHM_WINDOWS_CPU_TYPE=ARM64` so the bundled Boehm GC is built with
`CPU=ARM64`.

Depends on Mercury-Language/bdwgc#3 — the `boehm_gc` submodule pointer
bump in this PR relies on that `NT_MAKEFILE` change to land first on
`release-8_2-mercury`.

`Documentation/README.MS-VisualC.md` and `NEWS.md` are updated. The
expected output in `tests/warnings/help_text.err_exp` is updated to
include the new `msvc_arm64` value in the `--c-compiler-type` help.