### PR TITLE
Fix uint64.to_int/2 and uint32.to_int/2 on LLP64 platforms

### DIFF
--- a/library/uint32.m
+++ b/library/uint32.m
@@ -684,7 +684,7 @@ det_from_uint(U) = U32 :-
 #else
     uint32_t    mask_for_int;
 
-    mask_for_int = (1UL << 31) - 1;
+    mask_for_int = (UINT32_C(1) << 31) - 1;
     if ((U32 & (~mask_for_int)) == 0UL) {
         // Every bit in U32 means the same in I.
         I = (MR_Integer) U32;

--- a/library/uint64.m
+++ b/library/uint64.m
@@ -586,9 +586,9 @@ det_from_int(I) = U64 :-
     uint64_t    mask_for_int;
 
 #if MR_BYTES_PER_WORD == 8
-    mask_for_int = (1UL << 63) - 1;
+    mask_for_int = (UINT64_C(1) << 63) - 1;
 #else
-    mask_for_int = (1UL << 31) - 1;
+    mask_for_int = (UINT32_C(1) << 31) - 1;
 #endif
 
     if ((U64 & (~mask_for_int)) == 0UL) {


### PR DESCRIPTION
Fix uint64.to_int/2 and uint32.to_int/2 on LLP64 platforms.
The C foreign_proc bodies for uint64.to_int/2 and uint32.to_int/2 use
(1UL << 63) and (1UL << 31) to build a mask of representable Mercury
int values. On LLP64 platforms (notably 64-bit Windows with both
MinGW-w64 GCC and MSVC), unsigned long is 32 bits, so 1UL << 63 has
undefined behaviour: GCC's -Wshift-count-overflow rejects it under
-Werror, breaking the build, while clang silently folds the result to
zero, which makes mask_for_int wrap to ~0, so to_int and det_to_int
report success and truncate for every uint64 value, including ones
that do not fit in a Mercury int. The same reasoning applies to the
32-bit-word branch and to the corresponding code in uint32.m.

library/uint64.m:
    Replace (1UL << 63) with (UINT64_C(1) << 63) in the
    MR_BYTES_PER_WORD == 8 branch of to_int/2 so the literal is at
    least 64 bits on every platform. Replace (1UL << 31) with
    (UINT32_C(1) << 31) in the 32-bit-word branch for consistency.

library/uint32.m:
    Replace (1UL << 31) with (UINT32_C(1) << 31) in the
    MR_BYTES_PER_WORD != 8 branch of to_int/2.