### PR TITLE
Fix several typos in compiler source files

### DIFF
--- a/compiler/make.program_target.m
+++ b/compiler/make.program_target.m
@@ -1684,7 +1684,7 @@ build_c_library(ProgressStream, Globals, MainModuleName, AllModules, Succeeded,
             SharedLibsSupported = shared_libraries_not_supported,
             SharedLibsSucceeded = succeeded
         ),
-        % We can only build the .init file if we have succesfully built
+        % We can only build the .init file if we have successfully built
         % the .c files.
         (
             SharedLibsSucceeded = succeeded,

--- a/compiler/mercury_compile_make_hlds.m
+++ b/compiler/mercury_compile_make_hlds.m
@@ -354,7 +354,7 @@ maybe_mention_undoc(DocUndoc, Pieces0, Pieces) :-
         Pieces = Pieces0 ++
             [words("The Mercury standard library module in question"),
             words("is part of the Mercury implementation,"),
-            words("and is not publically documented."), nl]
+            words("and is not publicly documented."), nl]
     ).
 
 %---------------------%

--- a/compiler/quantification.m
+++ b/compiler/quantification.m
@@ -2646,7 +2646,7 @@ set_goal_nonlocals(NonLocalsToRecompute, NonLocals, !GoalInfo) :-
     %   OutsideVars will be [] and QuantifiedVars will be [X].
     % When processing `r(X)':
     %   OutsideVars will be [X] and QuantifiedVars will be [],
-    %   since now [X] has occured in a goal (`s(X)') outside of `r(X)'.
+    %   since now [X] has occurred in a goal (`s(X)') outside of `r(X)'.
     % When processing `not q(X)':
     %   OutsideVars will be [] and QuantifiedVars will be [X].
     % When processing `q(X)':

--- a/compiler/va_map.m
+++ b/compiler/va_map.m
@@ -17,7 +17,7 @@
 % Like a plain version array, it provides O(1) indexing and update when
 % accessing the latest version of the data structure.
 %
-% Unlike a plain version array, the data structure will grow to accomodate keys
+% Unlike a plain version array, the data structure will grow to accommodate keys
 % outside of the existing bounds. This is more like a map.
 %
 % Unlike a map, keys that were not explicitly set are implicitly associated


### PR DESCRIPTION
## Summary
- Fix "accomodate" → "accommodate" in `compiler/va_map.m` (comment)
- Fix "occured" → "occurred" in `compiler/quantification.m` (comment)
- Fix "publically" → "publicly" in `compiler/mercury_compile_make_hlds.m` (user-facing error message)
- Fix "succesfully" → "successfully" in `compiler/make.program_target.m` (comment)

## Test plan
- [x] Verified all changes are spelling corrections only, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)