### PR TITLE
Fix typos in runtime error message and developer notes

### DIFF
--- a/compiler/notes/bootstrapping.html
+++ b/compiler/notes/bootstrapping.html
@@ -34,7 +34,7 @@ if this hasn't been done earlier (such as when the diff was sent for review).
 Then you should wait until
 <ul>
 <li>
-a new rotd is publically available for download which has the first part, or
+a new rotd is publicly available for download which has the first part, or
 <li>
 everyone on the team has reported installing a new compiler, or
 <li>

--- a/runtime/mercury_memory_handlers.c
+++ b/runtime/mercury_memory_handlers.c
@@ -576,7 +576,7 @@ MR_explain_exception_record(EXCEPTION_RECORD *rec)
             MR_MemoryZone *zone;
 
             // Display AV address and access mode.
-            fprintf(stderr, "\n***   An access violation occured"
+            fprintf(stderr, "\n***   An access violation occurred"
                     " at address 0x%08" MR_INTEGER_LENGTH_MODIFIER
                     "x, while attempting"
                     " to ", (MR_Word) address);


### PR DESCRIPTION
## Summary
- Fix "occured" → "occurred" in `runtime/mercury_memory_handlers.c` (user-facing runtime error message printed on access violation)
- Fix "publically" → "publicly" in `compiler/notes/bootstrapping.html` (developer documentation)

## Test plan
- [x] Verified all changes are spelling corrections only, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)