### PR TITLE
Fix stale URLs and typo in deep_profiler/README

### DIFF
--- a/deep_profiler/README
+++ b/deep_profiler/README
@@ -1,12 +1,12 @@
 For documentation on the deep profiler, see the following:
 
   - The "Deep Profiler" section of the Mercury web page
-    <http://www.cs.mu.oz.au/mercury/information/deep_demo.html>
+    <https://mercurylang.org/documentation/deep_demo.html>
     gives an overview of what deep profiling is.
 
   - The deep profiling paper on our web site, "Deep profiling:
     engineering a profiler for a declarative programming language"
-    <http://www.cs.mu.oz.au/mercury/information/papers.html#mu_01_24>
+    <https://mercurylang.org/documentation/papers.html#mu_01_24>
     explains in detail what deep profiling is, why it is needed,
     and how it is implemented in the Mercury compiler.
 
@@ -14,4 +14,4 @@ For documentation on the deep profiler, see the following:
     Mercury user's guide explains how to use it.
 
   - The file deep_profiler/notes/deep_profiling.html gives an overview of
-    the specifics details of our implementation of deep profiling.
+    the specific details of our implementation of deep profiling.


### PR DESCRIPTION
## Summary
- Update two obsolete `www.cs.mu.oz.au` URLs to the current `mercurylang.org` domain
  - Deep profiler demo page: now at `https://mercurylang.org/documentation/deep_demo.html`
  - Deep profiling paper: now at `https://mercurylang.org/documentation/papers.html#mu_01_24`
- Fix "specifics details" → "specific details" on last line

The old `cs.mu.oz.au` domain appears to no longer serve the Mercury project pages. The content has moved to `mercurylang.org`.

## Test plan
- [x] Verified new URLs point to the correct content on mercurylang.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)