### PR TITLE
Fix bugs in Dockerfile: undefined variables and typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ARG MERCURY_DEV_TARGET
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE y
 
 # install packaged compiler for bootstrapping
-# first install curl and lsb-realse so we can add the public key for downloading
+# first install curl and lsb-release so we can add the public key for downloading
 # Mercury packages.
 # Then add the remote repository and install all packages required for building
 # the Mercury compiler from source.
@@ -66,11 +66,10 @@ RUN ( \
         ([ -f ./configure ] || ./prepare.sh) \
         && ./configure \
             --enable-libgrades=$MERCURY_DEV_LIBGRADES \
-            --with-default-grade=$MERCURY_DEFAULT_GRADE \
+            --with-default-grade=$MERCURY_DEV_DEFAULT_GRADE \
             --prefix=$MERCURY_DEV_PREFIX \
             --disable-symlinks \
         && make PARALLEL=$MERCURY_DEV_PARALLEL install \
-        && rm -fR ${MERCURY_BOOTSTRAP_TARGET} \
         && rm -fR $MERCURY_DEV_TARGET \
     )
 


### PR DESCRIPTION
## Summary
- Fix --with-default-grade using undefined MERCURY_DEFAULT_GRADE instead of MERCURY_DEV_DEFAULT_GRADE (defined on line 23). Previously this configure option was always passed as an empty string.
- Remove rm of undefined MERCURY_BOOTSTRAP_TARGET (was a no-op; cleanup of MERCURY_DEV_TARGET on the next line already handles this).
- Fix typo in comment: lsb-realse to lsb-release.

## Test plan
- Verified MERCURY_DEFAULT_GRADE and MERCURY_BOOTSTRAP_TARGET are not defined anywhere in the Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)